### PR TITLE
Prevent an abstraction leak in Evidence.php

### DIFF
--- a/Evidence.php
+++ b/Evidence.php
@@ -87,15 +87,15 @@ class Evidence
     */
     public function setFromWebRequest($server = null, $cookies = null, $query = null)
     {
-        if (!$server) {
+        if ($server === null) {
             $server = $_SERVER;
         }
 
-        if (!$cookies) {
+        if ($cookies === null) {
             $cookies = $_COOKIE;
         }
 
-        if (!$query) {
+        if ($query === null) {
             // Merge the GET and POST parameters favoring the GET keys if there
             // are keys that conflict.
             $query = array_merge($_POST, $_GET);
@@ -134,7 +134,7 @@ class Evidence
 
         // Protocol
 
-        if (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] == 1) || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+        if (isset($server['HTTPS']) && ($server['HTTPS'] == 'on' || $server['HTTPS'] == 1) || isset($server['HTTP_X_FORWARDED_PROTO']) && $server['HTTP_X_FORWARDED_PROTO'] == 'https') {
             $protocol = 'https';
         } else {
             $protocol = 'http';
@@ -142,8 +142,8 @@ class Evidence
 
         // Override protocol with referer header if set
 
-        if (isset($_SERVER["HTTP_REFERER"]) && $_SERVER["HTTP_REFERER"]) {
-            $protocol = parse_url($_SERVER["HTTP_REFERER"], PHP_URL_SCHEME);
+        if (isset($server["HTTP_REFERER"]) && $server["HTTP_REFERER"]) {
+            $protocol = parse_url($server["HTTP_REFERER"], PHP_URL_SCHEME);
         }
 
         $evidence["header.protocol"] = $protocol;


### PR DESCRIPTION
I already mentioned this while reporting a bug in your other repository.
This fix makes it possible to pass empty arrays into `public function setFromWebRequest($server = null, $cookies = null, $query = null)`.
It currently affects our production code.