### PR TITLE
Ignored config settings

### DIFF
--- a/Evidence.php
+++ b/Evidence.php
@@ -79,9 +79,11 @@ class Evidence
 
     /**
         * Extract evidence from a web request
-        * No argument version automatically reads from current request
-        * @param $_SERVER
-        * @param $_COOKIE
+        * No argument version automatically reads from current request using the
+        * $_SERVER, $_COOKIE, $_GET and $_POST globals
+        * @param $server key value pairs for the HTTP headers
+        * @param $cookies key value pairs for the cookies
+        * @param $query key value pairs for the form parameters
     */
     public function setFromWebRequest($server = null, $cookies = null, $query = null)
     {
@@ -94,7 +96,9 @@ class Evidence
         }
 
         if (!$query) {
-            $query = $_GET;
+            // Merge the GET and POST parameters favoring the GET keys if there
+            // are keys that conflict.
+            $query = array_merge($_POST, $_GET);
         }
 
         $evidence = array();
@@ -105,15 +109,18 @@ class Evidence
   
                 $key = strtolower($key);
   
+                error_log("header." . $key . ": " . $value, 0);
                 $evidence["header." . $key] = $value;
             }
         }
   
         foreach ($cookies as $key => $value) {
+            error_log("cookie." . $key . ": " . $value, 0);
             $evidence["cookie." . $key] = $value;
         }
 
         foreach ($query as $key => $value) {
+            error_log("query." . $key . ": " . $value, 0);
             $evidence["query." . $key] = $value;
         }
   

--- a/Evidence.php
+++ b/Evidence.php
@@ -87,15 +87,15 @@ class Evidence
     */
     public function setFromWebRequest($server = null, $cookies = null, $query = null)
     {
-        if (!$server) {
+        if ($server === null) {
             $server = $_SERVER;
         }
 
-        if (!$cookies) {
+        if ($cookies === null) {
             $cookies = $_COOKIE;
         }
 
-        if (!$query) {
+        if ($query === null) {
             // Merge the GET and POST parameters favoring the GET keys if there
             // are keys that conflict.
             $query = array_merge($_POST, $_GET);
@@ -134,7 +134,7 @@ class Evidence
 
         // Protocol
 
-        if (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] == 1) || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+        if (isset($server['HTTPS']) && ($server['HTTPS'] == 'on' || $server['HTTPS'] == 1) || isset($server['HTTP_X_FORWARDED_PROTO']) && $server['HTTP_X_FORWARDED_PROTO'] == 'https') {
             $protocol = 'https';
         } else {
             $protocol = 'http';
@@ -142,8 +142,8 @@ class Evidence
 
         // Override protocol with referer header if set
 
-        if (isset($_SERVER["HTTP_REFERER"]) && $_SERVER["HTTP_REFERER"]) {
-            $protocol = parse_url($_SERVER["HTTP_REFERER"], PHP_URL_SCHEME);
+        if (isset($server["HTTP_REFERER"]) && $server["HTTP_REFERER"]) {
+            $protocol = parse_url($server["HTTP_REFERER"], PHP_URL_SCHEME);
         }
 
         $evidence["header.protocol"] = $protocol;

--- a/PipelineBuilder.php
+++ b/PipelineBuilder.php
@@ -114,11 +114,42 @@ class PipelineBuilder
     */
     public function build()
     {
-        $this->flowElements = array_merge($this->flowElements, 
-                                        $this->getJavaScriptElements(), 
-                                        $this->getSetHeaderElements());
+        $this->flowElements = $this->generateElements();
 
         return new Pipeline($this->flowElements, $this->settings);
+    }
+
+    private function generateElements()
+    {
+        $javascriptElements = $this->getJavaScriptElements();
+        $setHeaderElements = $this->getSetHeaderElements();
+
+        $javascriptBuilderElementFilter = function ($element) {
+            return !empty($element->settings['_endpoint']);
+        };
+
+        return array(
+            $this->findElement([], "fiftyone\pipeline\devicedetection\DeviceDetectionOnPremise"),
+            $this->findElement($javascriptElements, SequenceElement::class),
+            $this->findElement($javascriptElements, JsonBundlerElement::class),
+            $this->findElement($javascriptElements, JavascriptBuilderElement::class, $javascriptBuilderElementFilter),
+            $this->findElement($setHeaderElements, SetHeaderElement::class)
+        );
+    }
+
+    private function findElement($elements, $class, $additionalFilter = null)
+    {
+        $typeFilter = function ($element) use ($class) {
+            return $element instanceof $class;
+        };
+
+        $result = array_filter(array_merge($elements, $this->flowElements), $typeFilter);
+
+        if ($additionalFilter !== null) {
+            $result = array_filter($result, $additionalFilter);
+        }
+
+        return reset($result);
     }
 
     /**

--- a/PipelineBuilder.php
+++ b/PipelineBuilder.php
@@ -131,8 +131,8 @@ class PipelineBuilder
             $this->getJavaScriptElements(),
             $this->getSetHeaderElements()
         );
-        $sequence = array_shift($otherElements);
 
+        // remove sequence, jsonbundler, javascriptbuilder duplicates
         foreach ($otherElements as $element) {
             foreach ($this->flowElements as $flowElement) {
                 // skip $element if present in $this->flowElements
@@ -145,7 +145,24 @@ class PipelineBuilder
             $this->flowElements[] = $element;
         }
 
-        // ensure correct element order
+        // find the sequence element by dataKey
+        $sequence = $otherElements[0];
+        $offset = array_search(
+            $sequence->dataKey,
+            array_map(
+                function ($flowElement) {
+                    return $flowElement->dataKey;
+                },
+                $this->flowElements
+            )
+        );
+
+        // when found, extract it from the list of elements
+        if ($offset !== false) {
+            $sequence = array_splice($this->flowElements, $offset, 1)[0];
+        }
+
+        // ensure the sequence element is the first one in the pipeline
         return array_merge([$sequence], $this->flowElements);
     }
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,2 +1,6 @@
 # API Specific CI/CD Approach
 This API complies with the `common-ci` approach.
+
+The following secrets are required:
+* `ACCESS_TOKEN` - GitHub [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) for cloning repos, creating PRs, etc.
+    * Example: `github_pat_l0ng_r4nd0m_s7r1ng`

--- a/tests/CoreTests.php
+++ b/tests/CoreTests.php
@@ -27,8 +27,11 @@ require(__DIR__ . "/../vendor/autoload.php");
 
 require(__DIR__ . "/classes/TestPipeline.php");
 
+use fiftyone\pipeline\core\JavascriptBuilderElement;
 use fiftyone\pipeline\core\PipelineBuilder;
 
+use fiftyone\pipeline\core\SequenceElement;
+use fiftyone\pipeline\core\SetHeaderElement;
 use fiftyone\pipeline\core\tests\ErrorFlowData;
 use fiftyone\pipeline\core\tests\StopFlowData;
 use fiftyone\pipeline\core\tests\MemoryLogger;
@@ -162,5 +165,89 @@ class CoreTests extends TestCase
         $flowElement1->updatePropertyList();
         $getValue = count($flowData->getWhere("testing", "true"));
         $this->assertTrue($getValue === 1);
+    }
+
+    public function testSequenceElementIsAlwaysFirstInPipeline()
+    {
+        $configFile = __DIR__ . '/testWebConfig.json';
+
+        $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
+        $this->assertSame(get_class(reset($pipeline->flowElements)), SequenceElement::class);
+
+        $pipeline = (new PipelineBuilder())->build();
+        $this->assertSame(get_class(reset($pipeline->flowElements)), SequenceElement::class);
+
+        $config = json_decode(file_get_contents($configFile), true);
+        $pipeline = (new PipelineBuilder($config))->build();
+        $this->assertSame(get_class(reset($pipeline->flowElements)), SequenceElement::class);
+    }
+
+    public function testSetHeaderElementIsAlwaysLastInPipeline()
+    {
+        $configFile = __DIR__ . '/testWebConfig.json';
+
+        $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
+        $this->assertSame(get_class(end($pipeline->flowElements)), SetHeaderElement::class);
+
+        $pipeline = (new PipelineBuilder())->build();
+        $this->assertSame(get_class(end($pipeline->flowElements)), SetHeaderElement::class);
+
+        $config = json_decode(file_get_contents($configFile), true);
+        $pipeline = (new PipelineBuilder($config))->build();
+        $this->assertSame(get_class(end($pipeline->flowElements)), SetHeaderElement::class);
+    }
+
+    public function testPipelineDoesntHaveDuplicateSequenceElements()
+    {
+        $configFile = __DIR__ . '/testWebConfig.json';
+        $filter = function ($element) {
+            return $element instanceof SequenceElement;
+        };
+
+        $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+
+        $pipeline = (new PipelineBuilder())->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+
+        $config = json_decode(file_get_contents($configFile), true);
+        $pipeline = (new PipelineBuilder($config))->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+    }
+
+    public function testPipelineDoesntHaveDuplicateJavascriptBuilderElements()
+    {
+        $configFile = __DIR__ . '/testWebConfig.json';
+        $filter = function ($element) {
+            return $element instanceof JavascriptBuilderElement;
+        };
+
+        $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+
+        $pipeline = (new PipelineBuilder())->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+
+        $config = json_decode(file_get_contents($configFile), true);
+        $pipeline = (new PipelineBuilder($config))->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+    }
+
+    public function testPipelineDoesntHaveDuplicateSetHeaderElements()
+    {
+        $configFile = __DIR__ . '/testWebConfig.json';
+        $filter = function ($element) {
+            return $element instanceof SetHeaderElement;
+        };
+
+        $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+
+        $pipeline = (new PipelineBuilder())->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+
+        $config = json_decode(file_get_contents($configFile), true);
+        $pipeline = (new PipelineBuilder($config))->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
     }
 }

--- a/tests/CoreTests.php
+++ b/tests/CoreTests.php
@@ -171,6 +171,9 @@ class CoreTests extends TestCase
     {
         $configFile = __DIR__ . '/testWebConfig.json';
 
+        $pipeline = (new PipelineBuilder())->add(new SequenceElement())->build();
+        $this->assertSame(get_class(reset($pipeline->flowElements)), SequenceElement::class);
+
         $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
         $this->assertSame(get_class(reset($pipeline->flowElements)), SequenceElement::class);
 
@@ -185,6 +188,9 @@ class CoreTests extends TestCase
     public function testSetHeaderElementIsAlwaysLastInPipeline()
     {
         $configFile = __DIR__ . '/testWebConfig.json';
+
+        $pipeline = (new PipelineBuilder())->add(new SetHeaderElement())->build();
+        $this->assertSame(get_class(end($pipeline->flowElements)), SetHeaderElement::class);
 
         $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
         $this->assertSame(get_class(end($pipeline->flowElements)), SetHeaderElement::class);
@@ -204,6 +210,9 @@ class CoreTests extends TestCase
             return $element instanceof SequenceElement;
         };
 
+        $pipeline = (new PipelineBuilder())->add(new SequenceElement())->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+
         $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
         $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
 
@@ -222,6 +231,9 @@ class CoreTests extends TestCase
             return $element instanceof JavascriptBuilderElement;
         };
 
+        $pipeline = (new PipelineBuilder())->add(new JavascriptBuilderElement())->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
+
         $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
         $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
 
@@ -239,6 +251,9 @@ class CoreTests extends TestCase
         $filter = function ($element) {
             return $element instanceof SetHeaderElement;
         };
+
+        $pipeline = (new PipelineBuilder())->add(new SetHeaderElement())->build();
+        $this->assertCount(1, array_filter($pipeline->flowElements, $filter));
 
         $pipeline = (new PipelineBuilder())->buildFromConfig($configFile)->build();
         $this->assertCount(1, array_filter($pipeline->flowElements, $filter));

--- a/tests/testWebConfig.json
+++ b/tests/testWebConfig.json
@@ -8,6 +8,9 @@
         "BuilderName": "fiftyone\\pipeline\\core\\SequenceElement"
       },
       {
+        "BuilderName": "fiftyone\\pipeline\\core\\SetHeaderElement"
+      },
+      {
         "BuilderName": "fiftyone\\pipeline\\core\\JavascriptBuilderElement",
         "BuildParameters": {
           "endpoint": "/json",

--- a/tests/testWebConfig.json
+++ b/tests/testWebConfig.json
@@ -1,0 +1,20 @@
+{
+  "PipelineOptions": {
+    "Elements": [
+      {
+        "BuilderName": "fiftyone\\pipeline\\core\\JsonBundlerElement"
+      },
+      {
+        "BuilderName": "fiftyone\\pipeline\\core\\SequenceElement"
+      },
+      {
+        "BuilderName": "fiftyone\\pipeline\\core\\JavascriptBuilderElement",
+        "BuildParameters": {
+          "endpoint": "/json",
+          "minify": true,
+          "enableCookies": true
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
It turns out that the `endpoint` setting wasn't ignored, rather there were two instances of `JavascriptBuilderElement`s passed to `Pipeline`'s constructor. 
The first was constructed with the settings from the json config file within a call to `PipelineBuilder::buildFromConfig()`, while the other came from `PipelineBuilder::getJavaScriptElements()` via a call to `array_merge()` in `PipelineBuilder::build()`. 
Because `PipelineBuilder`'s constructor did not receive any settings in `gettingStartedWeb.php`, it's `javascriptBuilderSettings` property is not declared, so `getJavaScriptElements()` returns an extra `JavascriptBuilderElement` without the settings from the json config file.
The list of elements passed to Pipeline's constructor is then: 
 1. `DeviceDetectionOnPremise` (from json config)
 2. `JsonBundlerElement` (from json config)
 3. `JavascriptBuilderElement` (from json config)
 4. `SequenceElement` (from `getJavaScriptElements()`)
 5. `JsonBundlerElement` (from `getJavaScriptElements()`)
 6. `JavascriptBuilderElement` (from `getJavaScriptElements()`)
 7. `SetHeaderElement` (from `getSetHeaderElements()`)

in that order. 
This behaviour isn't in accordance to the [spec](https://github.com/51Degrees/specifications/blob/main/pipeline-specification/features/web-integration.md#pipeline-configuration).

This PR provides element deduplication and ensures their order is correct, at least for the `gettingStartedWeb.php` example.