### PR TITLE
FlowElement default dummy constructor

### DIFF
--- a/FlowElement.php
+++ b/FlowElement.php
@@ -122,4 +122,17 @@ class FlowElement
             $pipeline->updatePropertyDatabaseForFlowElement($this);
         }
     }
+
+    /**
+     * A default dummy constructor is needed for there are classes inheriting this 
+     * class deeper than 1-level of inheritance and calling parent::__construct() in their
+     * explicit constructors unfortunately intermediates do not define their own __construct()
+     * so the call propagates up to the base class FlowElement and fails.  
+     * Intermediates might define their own __construct() at some point, so we do not want
+     * remove parent::__construct() calls, rather add this one as a catch all.
+     * 
+     * */
+    public function __construct() {
+
+    }
 }


### PR DESCRIPTION
A dummy default constructor function is needed because some deeper than 1-level inherited classes call `parent::__construct()` and we do not want to break this behavior as some intermediate classes might want to define some constructors later, but just don't at the moment.  Unfortunately PHP does not provide an implicit constructor like C++ would f.e. - so we have to keep this dummy one as an implicit default one. 

The constructor was accidentally removed as part of these [changes](https://github.com/51Degrees/pipeline-php-core/compare/4.4.3.0...4.4.4.0#diff-8817cf1b3ab25a092e9309c7bab4a4bda625ef7b0a1f1a190eb112131fbb67feL35) - this caused some dependent repository tests to fail.  So putting it back. 