### PR TITLE
SetHeaderElement.php: revert try-catch fix

### DIFF
--- a/SetHeaderElement.php
+++ b/SetHeaderElement.php
@@ -152,9 +152,13 @@ class SetHeaderElement extends FlowElement {
 		}
 
 		$propertyKey = strtolower($propertyKey);
-		if (isset($elementData->$propertyKey)) {
+		// TODO: catch is never called here. Consider replacing it with:
+		// if (isset($elementData->$propertyKey))
+		// The change can't be made right now, as it causes device-detection-php
+		// tests to fail. Further investigation is needed.
+		try {
             $property = $elementData->$propertyKey;
-		} else {
+		} catch (Exception $e) {
 			echo sprintf(Messages::PROPERTY_NOT_FOUND, $propertyKey, $elementKey);
 			return "";
 		}


### PR DESCRIPTION
This reverts the fix from here:
https://github.com/51Degrees/pipeline-php-core/compare/4.4.3.0...main#diff-2c905bd63ed59a54167749f6edb3e917e4742df635975daf813baa9f60e7f3efL155-L159

While the fix itself looks correct, it causes device-detection-php tests to fail, so for now lets revert it.